### PR TITLE
[A11y] Misc Screenreader Usability Improvements

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,6 +10,7 @@ const Footer = () => {
         target="_blank"
         rel="noreferrer"
         className="footer-icon-box"
+        aria-label="Curl on Steam"
       >
         <FaSteam className="footer-icon" />
       </a>
@@ -18,6 +19,7 @@ const Footer = () => {
         target="_blank"
         rel="noreferrer"
         classname="footer-icon-box"
+        aria-label="email"
       >
         <FaEnvelope className="footer-icon" />
       </a>
@@ -26,6 +28,7 @@ const Footer = () => {
         target="_blank"
         rel="noreferrer"
         className="footer-icon-box"
+        aria-label="Twitter"
       >
         <FaTwitter className="footer-icon" />
       </a>
@@ -34,6 +37,7 @@ const Footer = () => {
         target="_blank"
         rel="noreferrer"
         className="footer-icon-box"
+        aria-label='Discord'
       >
         <FaDiscord className="footer-icon" />
       </a>

--- a/src/components/MobileNav.jsx
+++ b/src/components/MobileNav.jsx
@@ -23,6 +23,8 @@ const MobileNav = () => {
       <button
         className={`nav-button${expanded ? ' nav-button-expanded' : ''}`}
         onClick={() => setExpanded(!expanded)}
+        aria-label="menu dropdown"
+        aria-expanded={expanded}
       >
         <BiMenu className="nav-button-icon" />
       </button>

--- a/src/components/SteamWidget.jsx
+++ b/src/components/SteamWidget.jsx
@@ -6,12 +6,12 @@ const SteamWidget = () => {
   return (
     <div className="widget">
       <div className="widget-header">
-        <h5 className="head">Curl! </h5>
-        <h5 className="tail">on Steam</h5>
+        <b className="head">Curl! </b>
+        <b className="tail">on Steam</b>
       </div>
       <div className="desc">
         <a href="https://store.steampowered.com/app/2100970/Curl/" target="_blank" rel="noreferrer">
-          <img src={capsule} alt="small logo" className="logo" />
+          <img src={capsule} alt="Curl logo" className="logo" />
         </a>
         <p className="desc">
           The beloved and captivating sport is spreading to new worlds! Take up the broom to challenge your friends locally or online to a competition of wit, teamwork, and silliness in this first-of-its-kind game, built for accessibility with brain-computer interface integration.
@@ -19,7 +19,7 @@ const SteamWidget = () => {
       </div>
       <div className="wishlist-container">
         <div className="date">
-          <h2 className="date">Available: Late 2022</h2>
+          <b className="date">Available: Late 2022</b>
         </div>
         <div className="wishlist-button">
           {/* <form action="https://store.steampowered.com//api/addtowishlist/" method='POST' target='_blank'>

--- a/src/routes/Home.jsx
+++ b/src/routes/Home.jsx
@@ -37,12 +37,11 @@ const Home = () => {
           loop
           muted
           playsInline
-          alt="showcase of gameplay"
+          aria-label="showcase of gameplay"
           className="section-image left"
         >
-          <source src={gameplayWebm} type="video/webm" />
-          <source src={gameplayMp4} type="video/mp4" />
-          Your browser does not support the video tag
+          <source src={gameplayWebm} type="video/webm" aria-hidden/>
+          <source src={gameplayMp4} type="video/mp4" aria-hidden/>
         </video>
         <p className="section-body">
           It’s a wacky mishmash of strategical sporting action that up to 4 players can enjoy. Slide ahead of your foes with a foolproof strategy. Weave each stone carefully down the ice to land victory in your orbit. Astound the crowd with explodinating, zappifying, and mind-discombobulating uber-cool super-stones! What’s that? Curling doesn’t have explosions? Sure, your primitive Earth curling might not, but <Title /> does!
@@ -87,12 +86,11 @@ const Home = () => {
           loop
           muted
           playsInline
-          alt="users navigating switch accessible menus"
+          aria-label="users navigating switch accessible menus"
           className="section-image left"
         >
           <source src={bciWebm} type="video/webm" />
           <source src={bciMp4} type="video/mp4" />
-          Your browser does not support the video tag
         </video>
         <p className="section-body">
           Menus and UI systems designed for use via switch-scanning selection, compatible with simple BCI alternative access.
@@ -151,7 +149,10 @@ const Home = () => {
         <div className="scroll-target" id="team" />
         <h1 className="section-header">The Team</h1>
         <p className="section-body-small">
-          We are a small collective of artists, musicians and programmers that seek to bring the medium of video games to those who might otherwise be unable to experience it. <br /> <br /> Through accessibility led design and cutting-edge technology, we want to expand the definition of who gets to play.
+          We are a small collective of artists, musicians and programmers that seek to bring the medium of video games to those who might otherwise be unable to experience it.
+        </p>
+        <p className="section-body-small">
+          Through accessibility led design and cutting-edge technology, we want to expand the definition of who gets to play.
         </p>
       </Section>
     </div>

--- a/src/styling/widget.css
+++ b/src/styling/widget.css
@@ -16,11 +16,12 @@
   font-size: calc(18px + 1vw);
   font-weight: normal;
 }
-h5.head {
+
+b.head {
   color: aliceblue;
   margin: calc(12px + 0.25vw) 0 calc(6px + 0.5vw) 0;
 }
-h5.tail {
+b.tail {
   color: #999;
   margin: calc(12px + 0.25vw) 0 calc(6px + 0.5vw) calc(4px + 0.25vw);
 }


### PR DESCRIPTION
Makes a few small structure changes from testing with NVDA screenreader. Styling changes are minimal (ex: paragraph indentation has changed on Home page where a `<p>` was added, otherwise everything should be identical).

Changes:
- Adds `aria-label`s to footer links
- Adds `aria-label` and expanded state to mobile nav menu button
- Replaces `h2` and `h5` header tags used for styling in Steam widget
- Replaces `alt` with `aria-label` on `<video>` elements so they no longer read as "blank"
- Replaces `<br>` (which read as "blank") in last section with a new `<p>` so semantics match visual design